### PR TITLE
evm: Deploy with create2

### DIFF
--- a/evm/.gitignore
+++ b/evm/.gitignore
@@ -13,3 +13,6 @@ docs/
 
 # Dotenv file
 .env
+
+# Flattened source
+flattened

--- a/evm/README.md
+++ b/evm/README.md
@@ -144,6 +144,18 @@ evm$ RPC_URL= MNEMONIC= OUR_CHAIN_ID= EVM_CHAIN_ID= ./sh/deployRouter.sh
 
 Note that the deploy script uses `create2` to generate a deterministic contract address.
 
+If you need to generate flattened source to be used for contract verification, you can use the following command. The results will be in `evm/flattened`.
+
+```shell
+evm$ ./sh/flatten.sh
+```
+
+To verify the Router contract, do something like this:
+
+```shell
+evm$ forge verify-contract --etherscan-api-key $ETHERSCAN_KEY --verifier etherscan --chain sepolia --watch --constructor-args $(cast abi-encode "constructor(uint16)" 10002)  0xB3375116c00873D3ED5781edFE304aC9cC75eA56 ./src/Router.sol:Router
+```
+
 ## Development
 
 ### Foundry

--- a/evm/README.md
+++ b/evm/README.md
@@ -134,6 +134,16 @@ struct IntegratorConfig {
 mapping(address => IntegratorConfig) integratorConfigs
 ```
 
+## Deploying the Router Contract
+
+The contract can be deployed using the following command.
+
+```shell
+evm$ RPC_URL= MNEMONIC= OUR_CHAIN_ID= EVM_CHAIN_ID= ./sh/deployRouter.sh
+```
+
+Note that the deploy script uses `create2` to generate a deterministic contract address.
+
 ## Development
 
 ### Foundry

--- a/evm/foundry.toml
+++ b/evm/foundry.toml
@@ -3,4 +3,10 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+solc_version = "0.8.24"
+evm_version = "paris"
+optimizer = true
+optimizer_runs = 200
+via_ir = false
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/evm/script/AddTransceiver.s.sol
+++ b/evm/script/AddTransceiver.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.19;
 
 import {Router} from "../src/Router.sol";
 import "forge-std/Script.sol";

--- a/evm/script/DeployRouter.s.sol
+++ b/evm/script/DeployRouter.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.19;
 
 import {Router, routerVersion} from "../src/Router.sol";
 import "forge-std/Script.sol";

--- a/evm/script/DeployRouter.s.sol
+++ b/evm/script/DeployRouter.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.4;
 
-import {Router} from "../src/Router.sol";
+import {Router, routerVersion} from "../src/Router.sol";
 import "forge-std/Script.sol";
 
 // DeployRouter is a forge script to deploy the Router contract. Use ./sh/deployRouter.sh to invoke this.
@@ -19,7 +19,8 @@ contract DeployRouter is Script {
     }
 
     function _deploy(uint16 ourChain) internal returns (address deployedAddress) {
-        Router router = new Router(ourChain);
+        bytes32 salt = keccak256(abi.encodePacked(routerVersion));
+        Router router = new Router{salt: salt}(ourChain);
 
         return (address(router));
     }

--- a/evm/script/DeployTestIntegrator.s.sol
+++ b/evm/script/DeployTestIntegrator.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.19;
 
 import {TestIntegrator} from "./TestIntegrator.s.sol";
 import "forge-std/Script.sol";

--- a/evm/script/SendTestMessage.s.sol
+++ b/evm/script/SendTestMessage.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.19;
 
 import {TestIntegrator} from "./TestIntegrator.s.sol";
 import "forge-std/Script.sol";

--- a/evm/script/TestIntegrator.s.sol
+++ b/evm/script/TestIntegrator.s.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.19;
 
 import {IRouterIntegrator} from "../src/interfaces/IRouterIntegrator.sol";
 import {IRouterAdmin} from "../src/interfaces/IRouterAdmin.sol";

--- a/evm/sh/deployRouter.sh
+++ b/evm/sh/deployRouter.sh
@@ -3,6 +3,7 @@
 #
 # This script deploys the Router contract.
 # Usage: RPC_URL= MNEMONIC= OUR_CHAIN_ID= EVM_CHAIN_ID= ./sh/deployRouter.sh
+#  To verify the contract add: FORGE_ARGS="--verifier-url 'https://api.routescan.io/v2/network/testnet/evm/${EVM_CHAIN_ID}/etherscan' --etherscan-api-key 'verifyContract'"
 #  tilt: ./sh/deployRouter.sh
 #
 

--- a/evm/sh/deployRouter.sh
+++ b/evm/sh/deployRouter.sh
@@ -3,7 +3,6 @@
 #
 # This script deploys the Router contract.
 # Usage: RPC_URL= MNEMONIC= OUR_CHAIN_ID= EVM_CHAIN_ID= ./sh/deployRouter.sh
-#  To verify the contract add: FORGE_ARGS="--verifier-url 'https://api.routescan.io/v2/network/testnet/evm/${EVM_CHAIN_ID}/etherscan' --etherscan-api-key 'verifyContract'"
 #  tilt: ./sh/deployRouter.sh
 #
 

--- a/evm/sh/flatten.sh
+++ b/evm/sh/flatten.sh
@@ -1,0 +1,9 @@
+rm -rf flattened
+mkdir flattened
+for fileName in \
+src/Router.sol
+  do
+	echo $fileName
+	flattened=flattened/`basename $fileName`
+	forge flatten --output $flattened $fileName
+done

--- a/evm/src/MessageSequence.sol
+++ b/evm/src/MessageSequence.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "./interfaces/IMessageSequence.sol";
 

--- a/evm/src/Router.sol
+++ b/evm/src/Router.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "./interfaces/IRouterAdmin.sol";
 import "./interfaces/IRouterIntegrator.sol";

--- a/evm/src/Router.sol
+++ b/evm/src/Router.sol
@@ -8,8 +8,10 @@ import "./MessageSequence.sol";
 import "./TransceiverRegistry.sol";
 import "./interfaces/ITransceiver.sol";
 
+string constant routerVersion = "Router-0.0.1";
+
 contract Router is IRouterAdmin, IRouterIntegrator, IRouterTransceiver, MessageSequence, TransceiverRegistry {
-    string public constant ROUTER_VERSION = "0.0.1";
+    string public constant ROUTER_VERSION = routerVersion;
 
     struct IntegratorConfig {
         bool isInitialized;

--- a/evm/src/TransceiverRegistry.sol
+++ b/evm/src/TransceiverRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 /// @title TransceiverRegistry
 /// @notice This contract is responsible for handling the registration of Transceivers.

--- a/evm/src/interfaces/IMessageSequence.sol
+++ b/evm/src/interfaces/IMessageSequence.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 interface IMessageSequence {
     /// @notice Returns the next message sequence for a given sender.

--- a/evm/src/interfaces/IRouterAdmin.sol
+++ b/evm/src/interfaces/IRouterAdmin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 interface IRouterAdmin {
     /// @notice Transfers admin privileges from the current admin to another contract.

--- a/evm/src/interfaces/IRouterIntegrator.sol
+++ b/evm/src/interfaces/IRouterIntegrator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "./IMessageSequence.sol";
 import "../libraries/UniversalAddress.sol";

--- a/evm/src/interfaces/IRouterTransceiver.sol
+++ b/evm/src/interfaces/IRouterTransceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "../libraries/UniversalAddress.sol";
 

--- a/evm/src/interfaces/ITransceiver.sol
+++ b/evm/src/interfaces/ITransceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 import "../libraries/UniversalAddress.sol";
 

--- a/evm/src/libraries/UniversalAddress.sol
+++ b/evm/src/libraries/UniversalAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.19;
 
 type UniversalAddress is bytes32;
 


### PR DESCRIPTION
From https://book.getfoundry.sh/tutorials/create2-tutorial 
> In forge scripts, using new MyContract{salt: salt}() will use the deterministic deployer at [0x4e59b44847b379578588920ca78fbf26c0b4956c](https://github.com/Arachnid/deterministic-deployment-proxy).